### PR TITLE
added missing dependency to react template

### DIFF
--- a/templates/application/react/ts/package.json
+++ b/templates/application/react/ts/package.json
@@ -28,6 +28,7 @@
     "postcss": "^8.2.1",
     "postcss-loader": "^4.1.0",
     "style-loader": "^3.3.0",
+    "typescript": "^4.5.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
     "webpack-dev-server": "^4.3.1"


### PR DESCRIPTION
# Missing typescript dependency for the react typescript template.

Without this dependency, the user of create-mf-app can receive unnecessary errors of missing dependencies

I can check the rest of the project for missing typescript dependency if necessary :)
