### PR TITLE
chore: added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
+
+#node
+yarn.lock
+
+#misc
+.husky
+assets
+
+#tests
+test
+coverage
+
+#linters
+.eslintrc*
+.eslintignore
+
+#editor settings
+.vscode
+.idea
+.editorconfig


### PR DESCRIPTION
# npmignore
Added .npmignore file to not upload unnecessary files to npm and to make the package size smaller in the long term in case we add more stuff to the repo that isn't relevant to the npm package.

This is done mainly for #13 #14 to ignore the eslint, husky, and assets files.

I have not added some files to the .npmignore file per the [npm docs](https://docs.npmjs.com/cli/v8/using-npm/developers)