### PR TITLE
chore: added publish workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,28 +1,21 @@
-name: "publish release"
-
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  publish-npm-release:
-    name: "publish to NPM"
-    runs-on: ubuntu-20.04
-    if: github.repository == 'jherr/create-mf-app'
+  publish:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm i -g npm@8
-    - run: npm run build
-    - run: utils/publish_all_packages.sh --release-candidate
-      if: "github.event.release.prerelease"
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: utils/publish_all_packages.sh --release
-      if: "!github.event.release.prerelease"
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      # - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,28 @@
+name: "publish release"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm-release:
+    name: "publish to NPM"
+    runs-on: ubuntu-20.04
+    if: github.repository == 'jherr/create-mf-app'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm i -g npm@8
+    - run: npm run build
+    - run: utils/publish_all_packages.sh --release-candidate
+      if: "github.event.release.prerelease"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: utils/publish_all_packages.sh --release
+      if: "!github.event.release.prerelease"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
# Publish Github Action
Added a Github Action to deploy the package to NPM. I have used a generic publish action using JS-DevTools' [action](https://github.com/marketplace/actions/npm-publish) and modified it to this repository.

The action will require an NPM token secret (@jherr token unless you make another user for uploading) to be used for publishing the package. `secrets.NPM_TOKEN`.

It's my first time using this action so I'll need @jherr help to see if it works and if there are any other requirements for this. Looking at the default values from the action it looks fine but we might want to change the tag or something.