### PR TITLE
Setup for Tailwind 3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export const buildProject = async (project: Project) => {
         const packageJSON = JSON.parse(
           fs.readFileSync(path.join(name, 'package.json'), 'utf8')
         )
-        packageJSON.devDependencies.tailwindcss = '^2.0.2'
+        packageJSON.devDependencies.tailwindcss = '^3.0.11'
         fs.writeFileSync(
           path.join(name, 'package.json'),
           JSON.stringify(packageJSON, null, 2)

--- a/templates/application-extras/tailwind/tailwind.config.js
+++ b/templates/application-extras/tailwind/tailwind.config.js
@@ -1,10 +1,7 @@
 module.exports = {
-  purge: [],
-  darkMode: false, // or 'media' or 'class'
+  mode: 'jit',
+  content: ['./src/**/*.{tsx,jsx}'],
   theme: {
-    extend: {},
-  },
-  variants: {
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
Basic setup for using Tailwind CSS v3.0.11 (latest), only configured for React (.tsx and .jsx files). tailwind.conf.js can be completed to work with other file types.

The problem is now that a Tailwind class from a remote module is only recognized if already used in the "home module" (i.e. the one that is using the remote component) :

If I use the "bg-sky-500" class in <RemoteComponent />, it disappears from the DOM of <RootApp /> using <RemoteComponent /> (the class does not even appear in the inspector).
No problem if "bg-sky-500" is used directly in <RootApp />