### PR TITLE
Remove invalid dependency

### DIFF
--- a/templates/server/nestjs-auth/package.json
+++ b/templates/server/nestjs-auth/package.json
@@ -21,7 +21,6 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@": "nestjs/passport",
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/jwt": "^8.0.0",


### PR DESCRIPTION
Hi @jherr,

thanks for this project - I really like it 👍 
Somehow, an invalid dependency found a way into the `nest-auth` example, which results in an error during installation ^1.
I just removed it, as the correct dependency is there as well (`@nestjs/passport": "^8.0.1",`)

1
```
npm ERR! code EINVALIDPACKAGENAME
npm ERR! Invalid package name "@": name can only contain URL-friendly characters
```