### PR TITLE
fix: Replace API Server template path for buildProject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export const buildProject = async (project: Project) => {
 
     case 'API Server':
       await ncp(
-        path.join(__dirname, `../templates/${tempDir}/${framework}`),
+        path.join(__dirname, `../templates/server/${framework}`),
         name
       )
       break


### PR DESCRIPTION
A quick fix to #47, merely replaced the template string `tempDir` with 'server'. Please do tell if there are any better options.