### PR TITLE
Handle the environment variable issue for frontend application

### DIFF
--- a/templates/application/inferno/base/webpack.config.js
+++ b/templates/application/inferno/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -60,5 +61,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/inferno/js/package.json
+++ b/templates/application/inferno/js/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/inferno/ts/package.json
+++ b/templates/application/inferno/ts/package.json
@@ -28,7 +28,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "inferno": "^7.4.10"

--- a/templates/application/lit-html/base/webpack.config.js
+++ b/templates/application/lit-html/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -52,5 +53,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/lit-html/js/package.json
+++ b/templates/application/lit-html/js/package.json
@@ -26,7 +26,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/lit-html/ts/package.json
+++ b/templates/application/lit-html/ts/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/mithril/base/webpack.config.js
+++ b/templates/application/mithril/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -52,5 +53,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/mithril/js/package.json
+++ b/templates/application/mithril/js/package.json
@@ -26,7 +26,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/mithril/ts/package.json
+++ b/templates/application/mithril/ts/package.json
@@ -28,7 +28,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/preact/base/webpack.config.js
+++ b/templates/application/preact/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -56,5 +57,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/preact/js/package.json
+++ b/templates/application/preact/js/package.json
@@ -28,7 +28,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/preact/ts/package.json
+++ b/templates/application/preact/ts/package.json
@@ -30,7 +30,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "preact": "^10.5.14"

--- a/templates/application/react-esm/base/webpack.config.js
+++ b/templates/application/react-esm/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -67,5 +68,6 @@ module.exports = (_, argv) => ({
       template: "./index.ejs",
       inject: false,
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/react-esm/js/package.json
+++ b/templates/application/react-esm/js/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/react-esm/ts/package.json
+++ b/templates/application/react-esm/ts/package.json
@@ -31,7 +31,8 @@
     "typescript": "^4.5.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/templates/application/react/base/webpack.config.js
+++ b/templates/application/react/base/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
-
+const Dotenv = require('dotenv-webpack');
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
   output: {
@@ -60,5 +60,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/react/js/package.json
+++ b/templates/application/react/js/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/react/ts/package.json
+++ b/templates/application/react/ts/package.json
@@ -31,7 +31,8 @@
     "typescript": "^4.5.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/templates/application/solid-js/base/webpack.config.js
+++ b/templates/application/solid-js/base/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const Dotenv = require('dotenv-webpack');
 
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
@@ -56,5 +57,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/solid-js/js/package.json
+++ b/templates/application/solid-js/js/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/solid-js/ts/package.json
+++ b/templates/application/solid-js/ts/package.json
@@ -28,7 +28,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/svelte/base/webpack.config.js
+++ b/templates/application/svelte/base/webpack.config.js
@@ -2,6 +2,7 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 const path = require("path");
+const Dotenv = require('dotenv-webpack');
 
 const mode = process.env.NODE_ENV || "development";
 const prod = mode === "production";
@@ -91,6 +92,7 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
   devtool: prod ? false : "source-map",
 });

--- a/templates/application/svelte/js/package.json
+++ b/templates/application/svelte/js/package.json
@@ -28,7 +28,8 @@
     "svelte-loader": "^3.1.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/svelte/ts/package.json
+++ b/templates/application/svelte/ts/package.json
@@ -29,7 +29,8 @@
     "svelte-loader": "^3.1.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",

--- a/templates/application/vanilla/base/webpack.config.js
+++ b/templates/application/vanilla/base/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
-
+const Dotenv = require('dotenv-webpack');
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
   output: {
@@ -52,5 +52,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/vanilla/js/package.json
+++ b/templates/application/vanilla/js/package.json
@@ -26,7 +26,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10"

--- a/templates/application/vanilla/ts/package.json
+++ b/templates/application/vanilla/ts/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10"

--- a/templates/application/vue2/base/webpack.config.js
+++ b/templates/application/vue2/base/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
-
+const Dotenv = require('dotenv-webpack');
 const deps = require("./package.json").dependencies;
 module.exports = (_, argv) => ({
   output: {
@@ -57,5 +57,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/vue2/js/package.json
+++ b/templates/application/vue2/js/package.json
@@ -27,7 +27,8 @@
     "vue-template-compiler": "^2.5.13",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "vue": "^2.6.14"

--- a/templates/application/vue2/ts/package.json
+++ b/templates/application/vue2/ts/package.json
@@ -28,7 +28,8 @@
     "vue-template-compiler": "^2.5.13",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "vue": "^2.6.14"

--- a/templates/application/vue3/base/webpack.config.js
+++ b/templates/application/vue3/base/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 const { VueLoaderPlugin } = require("vue-loader");
-
+const Dotenv = require('dotenv-webpack');
 module.exports = (_, argv) => ({
   output: {
     publicPath: "http://localhost:{{PORT}}/",
@@ -55,5 +55,6 @@ module.exports = (_, argv) => ({
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
+    new Dotenv()
   ],
 });

--- a/templates/application/vue3/js/package.json
+++ b/templates/application/vue3/js/package.json
@@ -28,7 +28,8 @@
     "vue-template-compiler": "^2.6.14",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "vue": "^3.2.19"

--- a/templates/application/vue3/ts/package.json
+++ b/templates/application/vue3/ts/package.json
@@ -31,7 +31,8 @@
     "vue-template-compiler": "^2.6.14",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",
-    "webpack-dev-server": "^4.3.1"
+    "webpack-dev-server": "^4.3.1",
+    "dotenv-webpack": "^8.0.1"
   },
   "dependencies": {
     "vue": "^3.2.19"


### PR DESCRIPTION
## Code Fix
- [x] Ensure Template for inferno could correctly handle environment variables.
- [ ] - [x] Ensure Template for lit-html could correctly handle environment variables.
- [x] Ensure Template for Vue3 could correctly handle environment variables.
## Issue URL
https://github.com/jherr/create-mf-app/issues/49
##  Steps to test: 
1. Checkout the code and run `npm run start`, ensure you choose framework = vue3 and Language = typescript / javascript
2. After the project is created,  run `npm install` to install the dependencies
3. Go to the folder and create a new .env file includes `VUE_APP_TITLE=My Testing App`.

3. Edit the App.Vue file so that in the script block, we have at least one statement to log the environment variable.
**Sample Typescript update**
```code
<script lang="ts">
  import { defineComponent } from 'vue'
  **console.log("my environment variable is: " + process.env.VUE_APP_TITLE)**
  export default defineComponent({});
</script>
```
4. Build the project `npm run build`
5. Run the project `npm run start`
### Expected result
In the browser console tab, you should have `my environment variable is: My Testing App` in the log