### PR TITLE
feat: bumping up rspack version and resolve related issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ export const buildProject = async (project: Project) => {
             name
           )
 
-          packageJSON.devDependencies.tailwindcss = '^2.0.2'
+          packageJSON.devDependencies.tailwindcss = '^3.4.1'
         }
         fs.writeFileSync(
           path.join(name, 'package.json'),

--- a/templates/application/lit-html/base/rspack.config.js
+++ b/templates/application/lit-html/base/rspack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve: {
+    extensions: ['.js','.ts','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/lit-html/js/package.rspack.json
+++ b/templates/application/lit-html/js/package.rspack.json
@@ -13,11 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "lit-html": "^2.0.1"

--- a/templates/application/lit-html/ts/package.rspack.json
+++ b/templates/application/lit-html/ts/package.rspack.json
@@ -13,11 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "lit-html": "^2.0.1"

--- a/templates/application/preact/base/rspack.config.js
+++ b/templates/application/preact/base/rspack.config.js
@@ -18,6 +18,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve: {
+    extensions: ['.js','.jsx','.ts','.tsx','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/preact/js/package.rspack.json
+++ b/templates/application/preact/js/package.rspack.json
@@ -13,12 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "preact": "^10.5.14"

--- a/templates/application/preact/ts/package.rspack.json
+++ b/templates/application/preact/ts/package.rspack.json
@@ -13,12 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "preact": "^10.5.14"

--- a/templates/application/react/base/rspack.config.js
+++ b/templates/application/react/base/rspack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve: {
+    extensions: ['.js','.jsx','.ts','.tsx','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/react/js/package.rspack.json
+++ b/templates/application/react/js/package.rspack.json
@@ -13,12 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/templates/application/react/ts/package.rspack.json
+++ b/templates/application/react/ts/package.rspack.json
@@ -13,14 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/templates/application/solid-js/base/rspack.config.js
+++ b/templates/application/solid-js/base/rspack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve: {
+    extensions: ['.js','.jsx','.ts','.tsx','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/solid-js/js/package.rspack.json
+++ b/templates/application/solid-js/js/package.rspack.json
@@ -13,6 +13,9 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "@babel/plugin-transform-runtime": "^7.23.7",
     "@babel/preset-env": "^7.23.8",
     "autoprefixer": "^10.1.0",
@@ -21,9 +24,7 @@
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "solid-refresh": "^0.6.3",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "solid-js": "^1.8.11"

--- a/templates/application/solid-js/ts/package.rspack.json
+++ b/templates/application/solid-js/ts/package.rspack.json
@@ -13,6 +13,9 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "@babel/plugin-transform-runtime": "^7.23.7",
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-typescript": "^7.23.3",
@@ -22,9 +25,7 @@
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "solid-refresh": "^0.6.3",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "solid-js": "^1.8.11"

--- a/templates/application/svelte/js/package.rspack.json
+++ b/templates/application/svelte/js/package.rspack.json
@@ -13,14 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "svelte-loader": "^3.1.9",
     "svelte-preprocess": "^5.1.3",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "svelte": "^4.2.9"

--- a/templates/application/svelte/ts/package.rspack.json
+++ b/templates/application/svelte/ts/package.rspack.json
@@ -13,14 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "svelte-loader": "^3.1.9",
     "svelte-preprocess": "^5.1.3",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2",
-    "@rspack/plugin-react-refresh": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "svelte": "^4.2.9"

--- a/templates/application/vanilla/base/rspack.config.js
+++ b/templates/application/vanilla/base/rspack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve:{
+    extensions: ['.js','.ts','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/vanilla/js/package.rspack.json
+++ b/templates/application/vanilla/js/package.rspack.json
@@ -13,11 +13,13 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {}
 }

--- a/templates/application/vanilla/ts/package.rspack.json
+++ b/templates/application/vanilla/ts/package.rspack.json
@@ -13,11 +13,13 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {}
 }

--- a/templates/application/vue3/base/rspack.config.js
+++ b/templates/application/vue3/base/rspack.config.js
@@ -15,6 +15,9 @@ module.exports = {
     historyApiFallback: true,
     port: {{PORT}},
   },
+  resolve: {
+    extensions: ['.js','.ts','.vue','.json']
+  },
   module: {
     rules: [
       {

--- a/templates/application/vue3/js/package.rspack.json
+++ b/templates/application/vue3/js/package.rspack.json
@@ -13,13 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "vue-loader": "^16.8.1",
     "vue-template-compiler": "^2.6.14",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "vue": "^3.2.19"

--- a/templates/application/vue3/ts/package.rspack.json
+++ b/templates/application/vue3/ts/package.rspack.json
@@ -13,13 +13,15 @@
     "email": "jherr@pobox.com"
   },
   "devDependencies": {
+    "@rspack/cli": "0.5.4",
+    "@rspack/core": "0.5.4",
+    "@rspack/plugin-react-refresh": "0.5.4",
     "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1",
     "postcss-loader": "^8.0.0",
     "vue-loader": "^16.8.1",
     "vue-template-compiler": "^2.6.14",
-    "@rspack/cli": "0.4.2",
-    "@rspack/core": "0.4.2"
+    "react-refresh": "^0.14.0"
   },
   "dependencies": {
     "vue": "^3.2.19"


### PR DESCRIPTION
## What I have done in this PR

- Rsolves issues related to bumping up the rspack versions that were raised in #59 

- Additionally, I have raised the version for tailwindcss

## Application's Tested:
- [x] lit-html-ts
- [x] lit-html
- [x] react-ts
- [x] react
- [x] react-ts
- [x] preact
- [x] preact-ts
- [x] solid 
- [x] solid-ts
- [x] svelte 
- [x] svelte-ts
- [x] vue3
- [x] vue3-ts

## Environment
-  OS: MacOs 
- Package Manager: bun

