### PR TITLE
Remove NODE_ENV=production and NODE_ENV=development from rspack scripts

### DIFF
--- a/templates/application/lit-html/js/package.rspack.json
+++ b/templates/application/lit-html/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/lit-html/ts/package.rspack.json
+++ b/templates/application/lit-html/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/preact/js/package.rspack.json
+++ b/templates/application/preact/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/preact/ts/package.rspack.json
+++ b/templates/application/preact/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/react/js/package.rspack.json
+++ b/templates/application/react/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/react/ts/package.rspack.json
+++ b/templates/application/react/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/solid-js/js/package.rspack.json
+++ b/templates/application/solid-js/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/solid-js/ts/package.rspack.json
+++ b/templates/application/solid-js/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/svelte/js/package.rspack.json
+++ b/templates/application/svelte/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/svelte/ts/package.rspack.json
+++ b/templates/application/svelte/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/vanilla/js/package.rspack.json
+++ b/templates/application/vanilla/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/vanilla/ts/package.rspack.json
+++ b/templates/application/vanilla/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/vue3/js/package.rspack.json
+++ b/templates/application/vue3/js/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {

--- a/templates/application/vue3/ts/package.rspack.json
+++ b/templates/application/vue3/ts/package.rspack.json
@@ -2,10 +2,10 @@
   "name": "{{NAME}}",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production rspack build",
-    "build:dev": "NODE_ENV=development rspack build",
+    "build": "rspack build",
+    "build:dev": "rspack build",
     "build:start": "cd dist && rspack serve",
-    "start": "NODE_ENV=development rspack serve"
+    "start": "rspack serve"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## 🧠 WHAT
Remove `NODE_ENV=production` and `NODE_ENV=development` from rspack scripts. So it works out of the box

## 📷 IMAGE
![image](https://github.com/jherr/create-mf-app/assets/80126839/e3abbc9c-c694-4abd-b7c1-9fb1ef80d9fa)
![image](https://github.com/jherr/create-mf-app/assets/80126839/395a1ca0-c741-4f66-b712-29c243fe448e)

https://github.com/jherr/create-mf-app/issues/70