### PR TITLE
Change path.join to path.resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ const templateFile = (fileName: string, replacements: Profiler) => {
 }
 
 const copyCompilationConfig = (projectName: string) => {
-  const sourcePath = path.join(__dirname, '../templates/compiler/compilation.config.js')
-  const destinationPath = path.join(projectName, 'compilation.config.js')
+  const sourcePath = path.resolve(__dirname, '../templates/compiler/compilation.config.js')
+  const destinationPath = path.resolve(projectName, 'compilation.config.js')
 
   fs.copyFileSync(sourcePath, destinationPath)
 }


### PR DESCRIPTION
## 🐛 BUG
There seems to be a bug in the last PR that I submitted for changing the way that the terminal shows the compiling message. Trying to create a new project with `npm start` in my forked repo created the mfe correctly. However now that the PR was merged, and a new release was published, when executing `npx create-mf-app`, the file `compilation.config.js` does not appear:
![image](https://github.com/user-attachments/assets/9721f1bd-3486-4d6c-87b9-02e0b0fde0f2)

This must be related to the way that I was copying the compilation file, this part:
![image](https://github.com/user-attachments/assets/207e9b7f-6857-4e82-9f8d-f2665fb5dcb3)

## ❓ Solution 

I was using path.join, and it seems not to be supported in npx projects ([forum](https://stackoverflow.com/questions/45677152/path-join-does-not-work)). Now I changed it to path.resolve. However I'm not sure if this is going to work, I executed `npm start` and it worked, just like when I was using path.join. But I'm unsure if this is going to solve the problem in the released version 🤒🤔