### PR TITLE
Fix: Now compilation.config file is only added in Application. Not in Server or Library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,10 +140,10 @@ export const buildProject = async (project: Project) => {
         path.join(name, 'package.json'),
         JSON.stringify(packageJSON, null, 2)
       )
+
+      copyCompilationConfig(name)
       break
   }
-
-  copyCompilationConfig(name)
 
   renameGitignore(name)
 


### PR DESCRIPTION
## 🐛 BUG
When creating an application, server and library a `compilation.config.js` file would be created.

However this file is intended to exist only when the user selects Application.

![image](https://github.com/user-attachments/assets/cfb3e328-bbd2-4c53-892c-a0b01eae5a1d)

![image](https://github.com/user-attachments/assets/c07da437-ff6e-42c5-862d-d248d0bf3b24)

![image](https://github.com/user-attachments/assets/fab04c83-0914-4500-9706-bc2023832d48)

## 🧠 Solution
`compilation.config.js` file is only created when the user selects Application 😀👍

Now servers, and libraries do not generate the file.
![image](https://github.com/user-attachments/assets/472eb34f-526f-4e50-94de-f6256ab5db86)

![image](https://github.com/user-attachments/assets/622e0816-3159-4561-b72d-e645d51fe784)

![image](https://github.com/user-attachments/assets/555507ff-5c6c-465c-87b3-ad4354b00523)



