### PR TITLE
Added tests and fixed using zephyr from CLI

### DIFF
--- a/bin/create-mf-app.ts
+++ b/bin/create-mf-app.ts
@@ -45,7 +45,10 @@ program
   )
   .option("-p, --port <number>", "The port to use")
   .option("-c, --css <css>", "The CSS framework to use (CSS or Tailwind)")
-  .option("-z", "--withZephyr", "Add deploy withZephyr")
+  .option(
+    "-z, --withZephyr <yes or no>",
+    "Add deploy withZephyr, sub second deployments on build"
+  )
   .option("-h, --help", "Help");
 
 program.parse();
@@ -149,19 +152,22 @@ function checkCancel(value: string | symbol) {
         })) as "CSS" | "Tailwind";
         checkCancel(answers.css);
       }
-
-      if (
-        answers.framework === "react-19" ||
-        answers.framework === "react-18"
-      ) {
-        answers.withZephyr = (await select({
-          message: "Add deploy withZephyr?",
-          options: [
-            { value: true, label: "Yes" },
-            { value: false, label: "No" },
-          ],
-          initialValue: true,
-        })) as boolean;
+      if (options.withZephyr) {
+        answers.withZephyr = options.withZephyr;
+      } else {
+        if (
+          answers.framework === "react-19" ||
+          answers.framework === "react-18"
+        ) {
+          answers.withZephyr = (await select({
+            message: "Add deploy withZephyr?",
+            options: [
+              { value: "yes", label: "Yes" },
+              { value: "no", label: "No" },
+            ],
+            initialValue: "yes",
+          })) as "yes" | "no";
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "tsc && node bin/create-mf-app.js",
     "build": "tsc",
     "lint": "eslint --fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "author": "Jack Herrington",
   "license": "MIT",
@@ -26,9 +28,10 @@
     "globals": "^15.14.0",
     "husky": "^7.0.4",
     "prettier": "^3.4.2",
-    "ts-node": "^10.4.0",
+    "ts-node": "^10.9.2",
     "typescript": "^4.5.3",
-    "typescript-eslint": "^8.22.0"
+    "typescript-eslint": "^8.22.0",
+    "vitest": "^1.4.0"
   },
   "packageManager": "pnpm@9.1.4"
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { buildProject } from "../index";
+
+describe("Project Generation", () => {
+  const testDir = "test-project";
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true });
+    }
+  });
+
+  describe("Application Projects", () => {
+    const frameworks = [
+      "react-18",
+      "react-19",
+      "vue3",
+      "svelte",
+      "preact",
+      "lit-html",
+      "solid-js",
+      "vanilla",
+    ];
+
+    frameworks.forEach((framework) => {
+      it(`should generate ${framework} application correctly`, async () => {
+        await buildProject({
+          name: testDir,
+          framework,
+          type: "Application",
+          css: "CSS",
+          withZephyr: 'no',
+        });
+
+        expect(fs.existsSync(testDir)).toBe(true);
+        expect(fs.existsSync(path.join(testDir, "package.json"))).toBe(true);
+        expect(fs.existsSync(path.join(testDir, "src"))).toBe(true);
+      });
+    });
+  });
+
+  describe("Library Projects", () => {
+    it("should generate TypeScript library correctly", async () => {
+      await buildProject({
+        name: testDir,
+        framework: "typescript",
+        type: "Library",
+        css: "CSS",
+        withZephyr: "no",
+      });
+
+      expect(fs.existsSync(testDir)).toBe(true);
+      expect(fs.existsSync(path.join(testDir, "package.json"))).toBe(true);
+      expect(fs.existsSync(path.join(testDir, "src"))).toBe(true);
+    });
+  });
+
+  describe("API Projects", () => {
+    const frameworks = [
+      "express",
+      "nestjs-auth",
+      "nestjs-todo",
+      "graphql-apollo",
+      "graphql-nexus",
+      "graphql-subscriptions",
+    ];
+
+    frameworks.forEach((framework) => {
+      it(`should generate ${framework} API correctly`, async () => {
+        await buildProject({
+          name: testDir,
+          framework,
+          type: "API",
+          css: "CSS",
+          withZephyr: 'no',
+        });
+
+        expect(fs.existsSync(testDir)).toBe(true);
+        expect(fs.existsSync(path.join(testDir, "package.json"))).toBe(true);
+        // expect(fs.existsSync(path.join(testDir, 'src'))).toBe(true);
+      });
+    });
+  });
+
+  describe("Tailwind Integration", () => {
+    it("should have correct Tailwind setup", async () => {
+      await buildProject({
+        name: testDir,
+        framework: "react-18",
+        type: "Application",
+        css: "Tailwind",
+        withZephyr: 'no',
+      });
+
+      const indexCssPath = path.join(testDir, "src/index.css");
+      const packageJsonPath = path.join(testDir, "package.json");
+
+      // Verify index.css exists and has correct content
+      expect(fs.existsSync(indexCssPath)).toBe(true);
+      const indexCssContent = fs.readFileSync(indexCssPath, "utf-8");
+      expect(indexCssContent.trim()).toBe('@import "tailwindcss";');
+
+      // Verify package.json has correct Tailwind dependencies
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+      expect(packageJson.devDependencies["@tailwindcss/postcss"]).toBe(
+        "^4.0.3"
+      );
+      expect(packageJson.devDependencies["tailwindcss"]).toBe("^4.0.3");
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { glob } from "glob";
 export type Project = {
   framework?: string;
   css?: "CSS" | "Tailwind";
-  withZephyr?: boolean;
+  withZephyr?: "yes"| "no";
   port?: number;
   name: string;
   type: "Application" | "Library" | "API";
@@ -88,7 +88,7 @@ const copyDirSync = (sourceDir: string, targetDir: string) => {
 };
 
 export const buildProject = async (project: Project) => {
-  const { name, framework, type } = project;
+  const { name, framework, type, withZephyr } = project;
   const tempDir = type.toLowerCase();
   const profiler = buildProfiler(project);
 
@@ -111,7 +111,7 @@ export const buildProject = async (project: Project) => {
       packageJSON.devDependencies["tailwindcss"] = "^4.0.3";
     }
 
-    if (project.withZephyr && project.framework === "react-19" || project.framework === "react-18") {
+    if (withZephyr === "yes" && project.framework === "react-19" || project.framework === "react-18") {
       copyDirSync(
         path.join(__dirname, "../templates/application-extras/withZephyr"),
         name

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*", "bin/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__/**/*"]
 }


### PR DESCRIPTION
Added the ability to add and exclude zephyr when creating a project not in interactive mode. 

![image](https://github.com/user-attachments/assets/3739ee73-17df-4edf-89c7-d2da751fc220)

`--name my-app --template react-19 --withZephyr yes  --css tailwind --port 8080`
`--name my-app --template react-19 --withZephyr no --css tailwind --port 8080`

It also works when you don't pass anything for none zephyr projects

`--name my-app --template svelte  --css tailwind --port 8080`