### PR TITLE
Update Zephyr Plugin to v0.0.47 for React 18 and 19 mf creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export const buildProject = async (project: Project) => {
     }
 
     if (withZephyr) {
-      packageJSON.dependencies["zephyr-rspack-plugin"] = "^0.0.32";
+      packageJSON.dependencies["zephyr-rspack-plugin"] = "^0.0.47";
     }
 
     await fs.writeFileSync(


### PR DESCRIPTION
This PR addresses [issue 80](https://github.com/jherr/create-mf-app/issues/80) by updating the zephyr-rspack-plugin to version 0.0.47, as recommended by the Zephyr team to resolve the intermittent build and deployment issues.

✅ Changes Included:
Updated src/index.ts to use the latest Zephyr plugin version

Ensured compatibility with both React 18 and React 19

Verified that build and deployment steps now complete consistently

🛠 Context:
The previous version of the Zephyr plugin occasionally failed to deploy updates even after a successful build. According to Zephyr support, this issue was tied to the outdated plugin version.